### PR TITLE
new controls, media dir, player settings (alwaysOnTop / opacity), per…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,10 @@ application {
     mainClassName = mainClass.get()
 }
 
+java {
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
 tasks {
     withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
         kotlinOptions {

--- a/config.vibin.json
+++ b/config.vibin.json
@@ -1,13 +1,17 @@
 {
-    "files": [
-        {
-            "file": "polish_cow.mp4"
-        },
-        {
-            "file": "sax_gandalf.mp4"
-        },
-        {
-            "file": "vibin.mp4"
-        }
-    ]
+  "player_settings" : {
+    "opacity" : 0.5,
+    "minOpacity" : 0.9,
+    "mediaDir" : "./media/"
+  },
+  "mediaOptions": [
+    {
+      "file": "polish_cow.mp4",
+      "defaultVolume" : 200
+    },
+    {
+      "file": "sax_gandalf.mp4",
+      "defaultVolume" : 50
+    }
+  ]
 }

--- a/src/main/kotlin/marais/vibin/Config.kt
+++ b/src/main/kotlin/marais/vibin/Config.kt
@@ -3,22 +3,38 @@ package marais.vibin
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class Config(val files: Array<ConfigEntry>) {
+data class Config(val mediaOptions: Array<MediaOptionsEntry>, val player_settings: PlayerSettings) {
     override fun equals(other: Any?): Boolean {
+
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
         other as Config
 
-        if (!files.contentEquals(other.files)) return false
+        if (!mediaOptions.contentEquals(other.mediaOptions)) return false
+        if (player_settings != other.player_settings) return false // fuck ça
 
         return true
     }
 
     override fun hashCode(): Int {
-        return files.contentHashCode()
+        return mediaOptions.contentHashCode() + player_settings.hashCode()
+    }
+
+    fun getMediaOptions(file : String) : MediaOptionsEntry? {
+
+        for (entry in mediaOptions)
+            if (entry.file == file) return entry;
+
+        return null;
     }
 }
 
 @Serializable
-data class ConfigEntry(val file: String, val scale: Float = 0.5f, val defaultVolume: Int = 80)
+data class MediaOptionsEntry(val file: String, val scale: Float = 0.5f, val defaultVolume: Int = 80)
+
+@Serializable
+data class PlayerSettings(val mediaDir : String = "./",
+                          val alwaysOnTop : Boolean = true,
+                          val opacity : Float = 1f,
+                          val minOpacity : Float = 0.05f)


### PR DESCRIPTION
…-media options

new controls : (App)
   + ctrl+mousewheel changes opacity in range player_settings.minOpacity <= opacity <= 1
   + ctrl+button1_click pauses video

media dir : (Config)
   + no need to declare every media you want to use
   + app finds all video medias in media dir using mime type
   + customizable media dir in config file

player settings : (Config)
   + settings relative the whole app
   + "alwaysOnTop" in "player_settings" : choose if app is always on top or not
   + "minimumOpacity" in "player_settings" : min opacity value ( 0 <= op <= 1) threshold
   + "opacity" in "player_settings" default opacity when launching app

per-media options : (Config)
   = "files" renamed to "mediaOptions"
   = (broken) each json object can control the default volume set before playing a media
   = can control other shit like "scale" which isn't used atm

known problems : (App)
   - "--volume tag doesn't seem to change anything" when using media.start